### PR TITLE
target_height == 0 means synced

### DIFF
--- a/NodoUI/src/NodoSyncInfo.cpp
+++ b/NodoUI/src/NodoSyncInfo.cpp
@@ -47,7 +47,7 @@ int NodoSyncInfo::getSyncPercentage(void)
     {
         if(m_targetHeight == 0)
         {
-            return -1;
+            return 100;
         }
     }
 


### PR DESCRIPTION
see https://github.com/monero-project/monero/blob/b089f9ee69924882c5d14dd1a6991deb05d9d1cd/src/rpc/core_rpc_server.cpp#L3263